### PR TITLE
rrs: fix use of rotation parameter

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -21,9 +21,13 @@ $a(k, l) = (\sum_{i = k}^{l} (X_i + C)) \mod M$
 
 $b(k, l) = (\sum_{i = k}^{l} (l - i + 1)(X_i + C)) \mod  M$
 
-$r(v) = (2^{R}v) \mod 2^{32}$
+$r(v) = \operatorname{rot}(R, v) \mod 2^{32}$
 
 $s(k, l) = r(a(k, l) + 2^{16}b(k, l))$
+
+Here, $\operatorname{rot}(R, v)$ means the result of rotating the bit vector $v$
+*left* by $R$ bits, that is, $v \ll R + v \gg (32 - R)$ (where the right shift
+is logical, not arithmetic).
 
 ## RRS0
 


### PR DESCRIPTION
Currently the spec performs rotation by multiplying by 2^R, which leaves zero bits on the right side of the bit vector. This is fixed by giving a correct definition of left rotation (hopefully I remembered the right LaTeX symbols). Please feel free to change the notation/presentation if it doesn't match the style you're going for.

I had the thought that the rotation parameter R could be replaced by a binary option, call it "style", that indicates which convention (rrs0 or rrs1) should be used; but I decided to stick with the smaller change for this PR.