### PR TITLE
Describe the hash tree construction

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -117,17 +117,15 @@ call $T$ the "threshold", as before, and $B$ the "step". Now for $X \in
 V_8$ we define $\operatorname{TREE}_{T, B, C} (X)$ recursively as
 follows:
 
-- If $|X| = 0$, $\operatorname{TREE}_{T, B, C} (X)$ is a leaf labelled
-  by $X$
-- Otherwise, if $I_{T, C}(X)$ exists, $\operatorname{TREE}_{T, B, C}
-  (X)$ is a node labelled by $X$ whose children in order are leaves
-  corresponding to, and labelled by, the entries of
-  $\operatorname{SPLIT}_{T, C} (X)$
-- Otherwise, $\operatorname{TREE}_{T, B, C}$ is a node labelled by $X$
-  whose children in order are the subtrees $\operatorname{TREE}_{T, B,
-  C} (Y)$ for each entry $Y$ in $\operatorname{SPLIT}_{T + nB, C} (X)$,
-  where $n$ is the largest integer such that $I_{T + nB, C} (X)$
-  exists.
+- If $I_{T, C} (X)$ does not exist, then $\operatorname{TREE}_{T, B, C}
+  (X)$ is a leaf labelled by $X$
+- Otherwise, let $n$ be the largest positive integer such that some
+  entry of $\operatorname{SPLIT}_{T + nB, C} (X)$, *other than the last
+  entry*, has length less than $S_{\text{max}}$, or zero if no such
+  positive integer exists. Then $\operatorname{TREE}_{T, B, C} (X)$ is a
+  node labelled by $X$ whose children in order are the subtrees
+  $\operatorname{TREE}_{T, B, C} (Y)$ for each entry $Y$ of
+  $\operatorname{SPLIT}_{T + nB, C} (X)$.
 
 Note the following properties of $\operatorname{TREE}_{T, B, C} (X)$:
 
@@ -136,7 +134,7 @@ Note the following properties of $\operatorname{TREE}_{T, B, C} (X)$:
 - The label of any non-leaf node is equal to the concatenation in order
   of the labels of its children
 - The labels of the leaf nodes in their natural order (inherited from
-  the inorder traversal of the tree) are exactly the
+  the depth-first traversal of the tree) are exactly the
   entries of $\operatorname{SPLIT}_{T, C} (X)$.
 
 # Rolling Hash Functions

--- a/spec.md
+++ b/spec.md
@@ -112,24 +112,24 @@ of which is itself a tree. The children of each node are ordered. A
 "leaf" is a node with zero children; for convenience, a tree whose root
 is a leaf node will also be referred to as a "leaf".
 
-Let $C$ be a configuration, and let $T$ and $S$ be positive integers. We
-call $T$ the "threshold", as before, and $S$ the "step". Now for $X \in
-V_8$ we define $\operatorname{TREE}_{T, S, C} (X)$ recursively as
+Let $C$ be a configuration, and let $T$ and $B$ be positive integers. We
+call $T$ the "threshold", as before, and $B$ the "step". Now for $X \in
+V_8$ we define $\operatorname{TREE}_{T, B, C} (X)$ recursively as
 follows:
 
-- If $|X| = 0$, $\operatorname{TREE}_{T, S, C} (X)$ is a leaf labelled
+- If $|X| = 0$, $\operatorname{TREE}_{T, B, C} (X)$ is a leaf labelled
   by $X$
-- Otherwise, if $I_{T, C}(X)$ exists, $\operatorname{TREE}_{T, S, C}
+- Otherwise, if $I_{T, C}(X)$ exists, $\operatorname{TREE}_{T, B, C}
   (X)$ is a node labelled by $X$ whose children in order are leaves
   corresponding to, and labelled by, the entries of
   $\operatorname{SPLIT}_{T, C} (X)$
-- Otherwise, $\operatorname{TREE}_{T, S, C}$ is a node labelled by $X$
-  whose children in order are the subtrees $\operatorname{TREE}_{T, S,
-  C} (Y)$ for each entry $Y$ in $\operatorname{SPLIT}_{T + nS, C} (X)$,
-  where $n$ is the largest integer such that $I_{T + nS, C} (X)$
+- Otherwise, $\operatorname{TREE}_{T, B, C}$ is a node labelled by $X$
+  whose children in order are the subtrees $\operatorname{TREE}_{T, B,
+  C} (Y)$ for each entry $Y$ in $\operatorname{SPLIT}_{T + nB, C} (X)$,
+  where $n$ is the largest integer such that $I_{T + nB, C} (X)$
   exists.
 
-Note the following properties of $\operatorname{TREE}_{T, S, C} (X)$:
+Note the following properties of $\operatorname{TREE}_{T, B, C} (X)$:
 
 - Each non-leaf node has at least two children
 - Each node is labelled by a nonempty element of $V_8$

--- a/spec.md
+++ b/spec.md
@@ -117,7 +117,7 @@ call $T$ the "threshold", as before, and $B$ the "step". Now for $X \in
 V_8$ we define $\operatorname{TREE}_{T, B, C} (X)$ recursively as
 follows:
 
-- If $I_{T, C} (X)$ does not exist, then $\operatorname{TREE}_{T, B, C}
+- If $I_{T, C} (X) = |X| - 1$, then $\operatorname{TREE}_{T, B, C}
   (X)$ is a leaf labelled by $X$
 - Otherwise, let $n$ be the largest positive integer such that some
   entry of $\operatorname{SPLIT}_{T + nB, C} (X)$, *other than the last

--- a/spec.md
+++ b/spec.md
@@ -72,21 +72,21 @@ We also use the following operators and functions:
 The primary result of this specification is to define a family of
 functions:
 
-$\operatorname{SPLIT}_C \in V_8 \rightarrow V_v$
+$\operatorname{SPLIT}_{T, C} \in V_8 \rightarrow V_v$
 
-...which is parameterized by a configuration $C$, consisting of:
+...which is parameterized by an integer $T \in U_{32}$, called the
+"threshold", and a configuration $C$, consisting of:
 
 - $S_{\text{min}} \in U_{32}$, the minimum split size
 - $S_{\text{max}} \in U_{32}$, the maximum split size
 - $H \in V_8 \rightarrow U_{32}$, the hash function
 - $W \in U_{32}$, the window size
-- $T \in U_{32}$, the threshold
 
 The configuration must satisfy $S_{\text{max}} \ge S_{\text{min}} \ge W > 0$.
 
 ## Definitions
 
-The "split index" $I(X)$, is either the smallest integer $i$ satisfying:
+The "split index" $I_{T, C}(X)$ is either the smallest integer $i$ satisfying:
 
 - $i < |X|$ and
 - $S_{\text{max}} \ge i \ge S_{\text{min}}$ and
@@ -94,11 +94,11 @@ The "split index" $I(X)$, is either the smallest integer $i$ satisfying:
 
 ...or $\min(|X| - 1, S_{\text{max}})$, if no such $i$ exists.
 
-We define $\operatorname{SPLIT}_C(X)$ recursively, as follows:
+We define $\operatorname{SPLIT}_{T, C}(X)$ recursively, as follows:
 
-- If $|X| = 0$, $\operatorname{SPLIT}_C(X) = \langle \rangle$
-- Otherwise, $\operatorname{SPLIT}_C(X) = \langle Y \rangle \mathbin{\|}
-  \operatorname{SPLIT}_C(Z)$ where
+- If $|X| = 0$, $\operatorname{SPLIT}_{T, C}(X) = \langle \rangle$
+- Otherwise, $\operatorname{SPLIT}_{T, C}(X) = \langle Y \rangle \mathbin{\|}
+  \operatorname{SPLIT}_{T, C}(Z)$ where
   - $i = I(X)$
   - $N = |X| - 1$
   - $Y = \langle X_0, \dots, X_i \rangle$
@@ -106,7 +106,38 @@ We define $\operatorname{SPLIT}_C(X)$ recursively, as follows:
 
 # Tree Construction
 
-TODO
+For our purposes, a tree consists of a node (the "root") with an
+associated value (its "label") along with zero or more children, each
+of which is itself a tree. The children of each node are ordered. A
+"leaf" is a node with zero children; for convenience, a tree whose root
+is a leaf node will also be referred to as a "leaf".
+
+Let $C$ be a configuration, and let $T$ and $S$ be positive integers. We
+call $T$ the "threshold", as before, and $S$ the "step". Now for $X \in
+V_8$ we define $\operatorname{TREE}_{T, S, C} (X)$ recursively as
+follows:
+
+- If $|X| = 0$, $\operatorname{TREE}_{T, S, C} (X)$ is a leaf labelled
+  by $X$
+- Otherwise, if $I_{T, C}(X)$ exists, $\operatorname{TREE}_{T, S, C}
+  (X)$ is a node labelled by $X$ whose children in order are leaves
+  corresponding to, and labelled by, the entries of
+  $\operatorname{SPLIT}_{T, C} (X)$
+- Otherwise, $\operatorname{TREE}_{T, S, C}$ is a node labelled by $X$
+  whose children in order are the subtrees $\operatorname{TREE}_{T, S,
+  C} (Y)$ for each entry $Y$ in $\operatorname{SPLIT}_{T + nS, C} (X)$,
+  where $n$ is the largest integer such that $I_{T + nS, C} (X)$
+  exists.
+
+Note the following properties of $\operatorname{TREE}_{T, S, C} (X)$:
+
+- Each non-leaf node has at least two children
+- Each node is labelled by a nonempty element of $V_8$
+- The label of any non-leaf node is equal to the concatenation in order
+  of the labels of its children
+- The labels of the leaf nodes in their natural order (inherited from
+  the inorder traversal of the tree) are exactly the
+  entries of $\operatorname{SPLIT}_{T, C} (X)$.
 
 # Rolling Hash Functions
 


### PR DESCRIPTION
This adds a formal description of how a tree is constructed by repeatedly splitting a sequence of bytes into segments. I'm sure there are some holes that need plugging, but I think I got at least the essentials right.

The first two commits in the PR are aesthetic tweaks to the LaTeX throughout the spec:

* replacing the ASCII notations `...` and `||` with LaTeX versions, `\dots` and `\mathbin{\|}` (which tend to have better spacing/layout properties)
* using the roman (non-italic) font variant for text subscripts like `max` and `min` (this improves spacing and I think is a little more readable)
* changing `\frac{x}{2^n}` to `x/2^n` (for inline fractions I find using a solidus works better than `\frac`, which is vertically cramped)

I don't mind reverting some of these if you prefer the original versions.

Closes #10.