### PR TITLE
Fix some off-by-one errors.

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -86,23 +86,23 @@ The configuration must satisfy $S_{\text{max}} \ge S_{\text{min}} \ge W > 0$.
 
 ## Definitions
 
-The "split index" $I(X)$, is either the smallest integer $i$ satisfying:
+The "split index" $I(X)$ of a sequence $X$ is either the smallest integer $i$ satisfying:
 
 - $i < |X|$ and
 - $S_{\text{max}} \ge i \ge S_{\text{min}}$ and
-- $H(\langle X_{i-W+1}, \dots, X_i \rangle) \mod 2^T = 0$
+- $H(\langle X_{\max(0, i-W)}, \dots, X_{i-1} \rangle) \mod 2^T = 0$
 
-...or $\min(|X| - 1, S_{\text{max}})$, if no such $i$ exists.
+...or $\min(|X|, S_{\text{max}})$, if no such $i$ exists.
+
+The “prefix” $P(X)$ of a non-empty sequence $X$ is $\langle X_0, \dots, X_{I(X)-1} \rangle$.
 
 We define $\operatorname{SPLIT}_C(X)$ recursively, as follows:
 
 - If $|X| = 0$, $\operatorname{SPLIT}_C(X) = \langle \rangle$
-- Otherwise, $\operatorname{SPLIT}_C(X) = \langle Y \rangle \mathbin{\|}
-  \operatorname{SPLIT}_C(Z)$ where
+- Otherwise, $\operatorname{SPLIT}_C(X) = P(X) \mathbin{\|} \operatorname{SPLIT}_C(Y)$ where
   - $i = I(X)$
-  - $N = |X| - 1$
-  - $Y = \langle X_0, \dots, X_i \rangle$
-  - $Z = \langle X_{i+1}, \dots, X_N \rangle$
+  - $N = |X|$
+  - $Y = \langle X_i, \dots, X_{N-1} \rangle$
 
 # Tree Construction
 

--- a/spec.md
+++ b/spec.md
@@ -101,7 +101,7 @@ The “remainder” $R(X)$ of a non-empty sequence $X$ is $\langle X_{I(X)}, \do
 We define $\operatorname{SPLIT}_C(X)$ recursively, as follows:
 
 - If $|X| = 0$, $\operatorname{SPLIT}_C(X) = \langle \rangle$
-- Otherwise, $\operatorname{SPLIT}_C(X) = P(X) \mathbin{\|} \operatorname{SPLIT}_C(R(X))$
+- Otherwise, $\operatorname{SPLIT}_C(X) = \langle P(X) \rangle \mathbin{\|} \operatorname{SPLIT}_C(R(X))$
 
 # Tree Construction
 

--- a/spec.md
+++ b/spec.md
@@ -88,7 +88,7 @@ The configuration must satisfy $S_{\text{max}} \ge S_{\text{min}} \ge W > 0$.
 
 The "split index" $I(X)$ of a sequence $X$ is either the smallest integer $i$ satisfying:
 
-- $i < |X|$ and
+- $i \le |X|$ and
 - $S_{\text{max}} \ge i \ge S_{\text{min}}$ and
 - $H(\langle X_{i-W}, \dots, X_{i-1} \rangle) \mod 2^T = 0$
 

--- a/spec.md
+++ b/spec.md
@@ -90,19 +90,18 @@ The "split index" $I(X)$ of a sequence $X$ is either the smallest integer $i$ sa
 
 - $i < |X|$ and
 - $S_{\text{max}} \ge i \ge S_{\text{min}}$ and
-- $H(\langle X_{\max(0, i-W)}, \dots, X_{i-1} \rangle) \mod 2^T = 0$
+- $H(\langle X_{i-W}, \dots, X_{i-1} \rangle) \mod 2^T = 0$
 
 ...or $\min(|X|, S_{\text{max}})$, if no such $i$ exists.
 
 The “prefix” $P(X)$ of a non-empty sequence $X$ is $\langle X_0, \dots, X_{I(X)-1} \rangle$.
 
+The “remainder” $R(X)$ of a non-empty sequence $X$ is $\langle X_{I(X)}, \dots, X_{|X|-1} \rangle$.
+
 We define $\operatorname{SPLIT}_C(X)$ recursively, as follows:
 
 - If $|X| = 0$, $\operatorname{SPLIT}_C(X) = \langle \rangle$
-- Otherwise, $\operatorname{SPLIT}_C(X) = P(X) \mathbin{\|} \operatorname{SPLIT}_C(Y)$ where
-  - $i = I(X)$
-  - $N = |X|$
-  - $Y = \langle X_i, \dots, X_{N-1} \rangle$
+- Otherwise, $\operatorname{SPLIT}_C(X) = P(X) \mathbin{\|} \operatorname{SPLIT}_C(R(X))$
 
 # Tree Construction
 


### PR DESCRIPTION
While beginning to draft some language for the "Tree Construction" section I discovered some inconsistencies in how chunk boundaries are described. Sometimes I(X) is the number of bytes in the chunk (e.g. "Smax >= i >= Smin") and sometimes it's the index of the last byte in the chunk ("Y = <X0, ..., Xi>").

I changed it so that I(X) is consistently the number of bytes in a chunk. I also created a definition for P(X), the prefix of X, i.e., the first chunk in X, which I intend to use in the definition of a tree but also used to simplify the definition of SPLITc(X).

(Please double-check this carefully. It's late and it's been a long day with weird apocalyptic orange skies you may have heard about, here in Northern California; I could easily have gotten this wrong.)