### PR TITLE
Fix (?) the cp32 spec

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -312,8 +312,8 @@ clear reasons for doing otherwise.
 We define the function $\operatorname{CP32} \in V_8 \rightarrow U_{32}$
 as:
 
-$\operatorname{CP32}(X) = \bigoplus_{i = 0}^{|X| - 1}
-\operatorname{ROT}_L(g(X_i), |X| - i + 1)$
+- $\operatorname{CP32}(X) = \bigoplus_{i = 0}^{|X| - 1} \operatorname{ROT}_L(g(X_i), |X| - i - 1)$ if $|X| > 0$
+- 0 otherwise
 
 Where $g(n) = G_n$ and the sequence $G \in V_{32}$ is defined in the
 appendix.


### PR DESCRIPTION
The cp32 spec says that the hash of a string X is the xor of rotl(g(xi), |X|-i+1) for each i in 0..|X|-1.

That means that the first g value gets rotl'd by |X|+1 bits, the second gets rotl'd by |X| bits, the third by |X|-1 bits, and so on, until the last g value gets rotl'd by 2 bits.

This seems like it might be a simple typo, and the `+1` should perhaps be a `-1`. Then the first g value gets rotl'd by |X|-1 bits, then |X|-2, and so on until the last g value gets rotl'd by 0 bits.

Was that in fact the intent?

(With the advent of [iterators in Go 1.23](https://tip.golang.org/blog/range-functions), I went back to my hashsplit package to [update its API](https://github.com/bobg/hashsplit/releases/tag/v2.0.0). In the process I rediscovered [this old PR draft](https://github.com/bobg/hashsplit/pull/3) and so decided to take the advice in it and add [my own implementation of cp32](https://github.com/bobg/hashsplit/pull/5), which is why I'm looking at this again after all this time.)